### PR TITLE
Hotfix: url / missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,8 +92,8 @@ app.use((req, res, next) => {
 
 // There will be a test page available on the /test path of your server url
 // Remove this before launching your app
-app.get('/test', function(req, res) {
-  res.send('Ok');
+app.get('/', function(req, res) {
+  res.send('Welcome to this api');
 });
 
 //Routes


### PR DESCRIPTION
While deploying in the serve threw an error because the "/" endpoint did not exists